### PR TITLE
Add Item costs to Item frames

### DIFF
--- a/src/ScootsVendorForge/ScootsVendorForge-core.lua
+++ b/src/ScootsVendorForge/ScootsVendorForge-core.lua
@@ -113,6 +113,7 @@ end
 ScootsVendorForge.refreshPanel = function()
     ScootsVendorForge.refreshPanelEvent = false
     ScootsVendorForge.hideAllItemFrames()
+	--ScootsVendorForge.hideAllCurrencyFrames()
     ScootsVendorForge.loadingIcon:Hide()
     ScootsVendorForge.loadingText:Hide()
     
@@ -169,11 +170,14 @@ ScootsVendorForge.refreshPanel = function()
     local purchasableItems = {}
     local frameIndex = 0
     local offset = 0
+	ScootsVendorForge.currencyIndex = 0
+	ScootsVendorForge.allAttuneCurrencies = {}
+    ScootsVendorForge.totalAttuneCurrency = {}
     for itemIndex = 1, GetMerchantNumItems() do
         local itemId, itemLink = Custom_GetMerchantItem(itemIndex)
         local tags = GetItemTagsCustom(itemId)
         local rarity = select(3, GetItemInfo(itemLink))
-        
+		local _, _, price, _, _, isUsable, extendedCost = GetMerchantItemInfo(itemIndex)
         if( rarity
         and rarity >= 2
         and rarity <= 4
@@ -187,9 +191,10 @@ ScootsVendorForge.refreshPanel = function()
                 ['index'] = itemIndex,
                 ['id'] = itemId,
                 ['link'] = itemLink,
-                ['forge'] = GetItemAttuneForge(itemId)
+                ['forge'] = GetItemAttuneForge(itemId),
+                ['cost'] = price,
+                ['extCost'] = extendedCost
             }
-            
             frameIndex = frameIndex + 1
             offset = ScootsVendorForge.setItemFrame(frameIndex, item, offset)
             table.insert(purchasableItems, item)

--- a/src/ScootsVendorForge/ScootsVendorForge-core.lua
+++ b/src/ScootsVendorForge/ScootsVendorForge-core.lua
@@ -113,7 +113,6 @@ end
 ScootsVendorForge.refreshPanel = function()
     ScootsVendorForge.refreshPanelEvent = false
     ScootsVendorForge.hideAllItemFrames()
-	--ScootsVendorForge.hideAllCurrencyFrames()
     ScootsVendorForge.loadingIcon:Hide()
     ScootsVendorForge.loadingText:Hide()
     

--- a/src/ScootsVendorForge/ScootsVendorForge-core.lua
+++ b/src/ScootsVendorForge/ScootsVendorForge-core.lua
@@ -169,14 +169,14 @@ ScootsVendorForge.refreshPanel = function()
     local purchasableItems = {}
     local frameIndex = 0
     local offset = 0
-	ScootsVendorForge.currencyIndex = 0
-	ScootsVendorForge.allAttuneCurrencies = {}
+    ScootsVendorForge.currencyIndex = 0
+    ScootsVendorForge.allAttuneCurrencies = {}
     ScootsVendorForge.totalAttuneCurrency = {}
     for itemIndex = 1, GetMerchantNumItems() do
         local itemId, itemLink = Custom_GetMerchantItem(itemIndex)
         local tags = GetItemTagsCustom(itemId)
         local rarity = select(3, GetItemInfo(itemLink))
-		local _, _, price, _, _, isUsable, extendedCost = GetMerchantItemInfo(itemIndex)
+        local _, _, price, _, _, isUsable, extendedCost = GetMerchantItemInfo(itemIndex)
         if( rarity
         and rarity >= 2
         and rarity <= 4

--- a/src/ScootsVendorForge/ScootsVendorForge-ui.lua
+++ b/src/ScootsVendorForge/ScootsVendorForge-ui.lua
@@ -273,7 +273,7 @@ ScootsVendorForge.setForgeLevelValues = function(self, level, menuList)
         info.func = function()
             UIDropDownMenu_SetText(ScootsVendorForge.frames.forgeLevel, choice[2])
             ScootsVendorForge.setOption('forgelevel', choice[1])
-			ScootsVendorForge.refreshPanel()
+            ScootsVendorForge.refreshPanel()
         end
         
         UIDropDownMenu_AddButton(info, level)
@@ -283,16 +283,16 @@ end
 ScootsVendorForge.hideAllItemFrames = function()
     for _, frame in pairs(ScootsVendorForge.frames.items) do
         frame:Hide()
-		if frame.currency then
-			for _, subframe in pairs(frame.currency) do
-				subframe:Hide()
-			end
-		end
-		if frame.expCurrency then
-			for _, subframe in pairs(frame.expCurrency) do
-				subframe:Hide()
-			end
-		end
+        if frame.currency then
+            for _, subframe in pairs(frame.currency) do
+                subframe:Hide()
+            end
+        end
+        if frame.expCurrency then
+            for _, subframe in pairs(frame.expCurrency) do
+                subframe:Hide()
+            end
+        end
     end
 end
 
@@ -323,11 +323,11 @@ ScootsVendorForge.setItemFrame = function(index, item, offset)
         ScootsVendorForge.frames.items[index].text:SetFontObject('GameFontNormal')
         ScootsVendorForge.frames.items[index].text:SetPoint('TOPLEFT', ScootsVendorForge.frames.items[index].icon:GetWidth() + 8, -4)
         ScootsVendorForge.frames.items[index].text:SetJustifyH('LEFT')
-		ScootsVendorForge.frames.items[index].text:SetWordWrap(false)
-		ScootsVendorForge.frames.items[index].text:SetNonSpaceWrap(false)
-		
-		
-		ScootsVendorForge.frames.items[index].expCostText = ScootsVendorForge.frames.items[index]:CreateFontString(nil, 'ARTWORK')
+        ScootsVendorForge.frames.items[index].text:SetWordWrap(false)
+        ScootsVendorForge.frames.items[index].text:SetNonSpaceWrap(false)
+        
+        
+        ScootsVendorForge.frames.items[index].expCostText = ScootsVendorForge.frames.items[index]:CreateFontString(nil, 'ARTWORK')
         ScootsVendorForge.frames.items[index].expCostText:SetWidth(ScootsVendorForge.frames.scrollChild:GetWidth() - (12 + ScootsVendorForge.frames.items[index].icon:GetWidth()))
         ScootsVendorForge.frames.items[index].expCostText:SetFontObject('GameFontNormal')
         ScootsVendorForge.frames.items[index].expCostText:SetPoint('BOTTOMLEFT', ScootsVendorForge.frames.items[index], 'BOTTOMLEFT', 30, ScootsVendorForge.borderThickness * 5)
@@ -344,16 +344,16 @@ ScootsVendorForge.setItemFrame = function(index, item, offset)
     
     ScootsVendorForge.frames.items[index].text:SetTextColor(colours.front.r, colours.front.g, colours.front.b)
     ScootsVendorForge.frames.items[index].text:SetText(select(1, GetItemInfo(item.link)))
-	
-	ScootsVendorForge.frames.items[index].expCostText:SetText("Exp. Cost: ")
-	ScootsVendorForge.frames.items[index].expCostText:Hide()
+    
+    ScootsVendorForge.frames.items[index].expCostText:SetText("Exp. Cost: ")
+    ScootsVendorForge.frames.items[index].expCostText:Hide()
     
     ScootsVendorForge.frames.items[index]:SetHeight(math.max(ScootsVendorForge.frames.items[index].icon:GetHeight(), ScootsVendorForge.frames.items[index].text:GetHeight()) + 8)
     
-	
-	local currencies = ScootsVendorForge.buildCurrencyArray(item,false)
+    
+    local currencies = ScootsVendorForge.buildCurrencyArray(item,false)
     ScootsVendorForge.frames.items[index].currency ={}
-	ScootsVendorForge.currencyIndex = 0
+    ScootsVendorForge.currencyIndex = 0
     leftOffset = 30
     for currencyIndex, currency in ipairs(currencies) do
         ScootsVendorForge.currencyIndex = ScootsVendorForge.currencyIndex + 1
@@ -361,7 +361,7 @@ ScootsVendorForge.setItemFrame = function(index, item, offset)
         
         currencyFrame:SetParent(ScootsVendorForge.frames.items[index])
         currencyFrame.currencyName = currency.name
-		
+        
         currencyFrame.text:SetText('|T' .. currency.icon .. ':' .. ScootsVendorForge.currencySize .. ':' ..  ScootsVendorForge.currencySize .. '|t' .. currency.amnt)
         currencyFrame:SetSize(currencyFrame.text:GetStringWidth(), ScootsVendorForge.currencySize)
         
@@ -382,10 +382,10 @@ ScootsVendorForge.setItemFrame = function(index, item, offset)
             ScootsVendorForge.totalAttuneCurrency[currency.name].total = ScootsVendorForge.totalAttuneCurrency[currency.name].total + currency.amnt
         end
     end
-	
-	local expCurrencies = ScootsVendorForge.buildCurrencyArray(item,true)
+    
+    local expCurrencies = ScootsVendorForge.buildCurrencyArray(item,true)
     ScootsVendorForge.frames.items[index].expCurrency ={}
-	ScootsVendorForge.currencyIndex = 0
+    ScootsVendorForge.currencyIndex = 0
     leftOffset = 92
     for currencyIndex, expCurrency in ipairs(expCurrencies) do
         ScootsVendorForge.currencyIndex = ScootsVendorForge.currencyIndex + 1
@@ -393,7 +393,7 @@ ScootsVendorForge.setItemFrame = function(index, item, offset)
         
         expCurrencyFrame:SetParent(ScootsVendorForge.frames.items[index])
         expCurrencyFrame.expCurrencyName = expCurrency.name
-		
+        
         expCurrencyFrame.text:SetText('|T' .. expCurrency.icon .. ':' .. ScootsVendorForge.currencySize .. ':' ..  ScootsVendorForge.currencySize .. '|t' .. expCurrency.amnt)
         expCurrencyFrame:SetSize(expCurrencyFrame.text:GetStringWidth(), ScootsVendorForge.currencySize)
         
@@ -413,16 +413,16 @@ ScootsVendorForge.setItemFrame = function(index, item, offset)
             
             ScootsVendorForge.totalAttuneCurrency[expCurrency.name].total = ScootsVendorForge.totalAttuneCurrency[expCurrency.name].total + expCurrency.amnt
         end
-		expCurrencyFrame:Hide()
+        expCurrencyFrame:Hide()
     end
-	
+    
     ScootsVendorForge.frames.items[index]:SetScript('OnEnter', function()
         ScootsVendorForge.frames.items[index].hover = true
         
         GameTooltip:SetOwner(ScootsVendorForge.frames.items[index], 'ANCHOR_RIGHT')
         GameTooltip:SetHyperlink(item.link)
     end)
-	
+    
     ScootsVendorForge.frames.items[index]:SetScript('OnLeave', function()
         ScootsVendorForge.frames.items[index].hover = false
        
@@ -460,36 +460,36 @@ ScootsVendorForge.setItemFrame = function(index, item, offset)
         if(ScootsVendorForge.frames.items[index].hover) then
             ShowMerchantSellCursor(item.index)
         end
-		if(ScootsVendorForge.frames.items[index]:IsMouseOver() and not ScootsVendorForge.frames.items[index].expCostText:IsVisible()) then
-				
-			ScootsVendorForge.frames.items[index].background:SetTexture(colours.back.r, colours.back.g, colours.back.b, colours.back.a + 0.1)
-			ScootsVendorForge.frames.items[index].borderTop:SetTexture(colours.front.r, colours.front.g, colours.front.b, colours.front.a + 0.1)
-			ScootsVendorForge.frames.items[index].borderBottom:SetTexture(colours.front.r, colours.front.g, colours.front.b, colours.front.a + 0.1)
-			
+        if(ScootsVendorForge.frames.items[index]:IsMouseOver() and not ScootsVendorForge.frames.items[index].expCostText:IsVisible()) then
+                
+            ScootsVendorForge.frames.items[index].background:SetTexture(colours.back.r, colours.back.g, colours.back.b, colours.back.a + 0.1)
+            ScootsVendorForge.frames.items[index].borderTop:SetTexture(colours.front.r, colours.front.g, colours.front.b, colours.front.a + 0.1)
+            ScootsVendorForge.frames.items[index].borderBottom:SetTexture(colours.front.r, colours.front.g, colours.front.b, colours.front.a + 0.1)
+            
             for _, frame in pairs(ScootsVendorForge.frames.items[index].currency) do
-				frame:Hide()
-			end
-			
-			ScootsVendorForge.frames.items[index].expCostText:Show()
-			for _, frame in pairs(ScootsVendorForge.frames.items[index].expCurrency) do
-				frame:Show()
-			end
+                frame:Hide()
+            end
+            
+            ScootsVendorForge.frames.items[index].expCostText:Show()
+            for _, frame in pairs(ScootsVendorForge.frames.items[index].expCurrency) do
+                frame:Show()
+            end
         end
            
         if(not ScootsVendorForge.frames.items[index]:IsMouseOver() and ScootsVendorForge.frames.items[index].expCostText:IsVisible()) then
-		
-			ScootsVendorForge.frames.items[index].background:SetTexture(colours.back.r, colours.back.g, colours.back.b, colours.back.a)
-			ScootsVendorForge.frames.items[index].borderTop:SetTexture(colours.front.r, colours.front.g, colours.front.b, colours.front.a)
-			ScootsVendorForge.frames.items[index].borderBottom:SetTexture(colours.front.r, colours.front.g, colours.front.b, colours.front.a)
-			
+        
+            ScootsVendorForge.frames.items[index].background:SetTexture(colours.back.r, colours.back.g, colours.back.b, colours.back.a)
+            ScootsVendorForge.frames.items[index].borderTop:SetTexture(colours.front.r, colours.front.g, colours.front.b, colours.front.a)
+            ScootsVendorForge.frames.items[index].borderBottom:SetTexture(colours.front.r, colours.front.g, colours.front.b, colours.front.a)
+            
             ScootsVendorForge.frames.items[index].expCostText:Hide()
-			for _, frame in pairs(ScootsVendorForge.frames.items[index].expCurrency) do
-				frame:Hide()
-			end
-			
-			for _, frame in pairs(ScootsVendorForge.frames.items[index].currency) do
-				frame:Show()
-			end
+            for _, frame in pairs(ScootsVendorForge.frames.items[index].expCurrency) do
+                frame:Hide()
+            end
+            
+            for _, frame in pairs(ScootsVendorForge.frames.items[index].currency) do
+                frame:Show()
+            end
         end
     end)
     

--- a/src/ScootsVendorForge/ScootsVendorForge-ui.lua
+++ b/src/ScootsVendorForge/ScootsVendorForge-ui.lua
@@ -1,7 +1,6 @@
 ScootsVendorForge = ScootsVendorForge or {}
 
 ScootsVendorForge.frameStrata = 'MEDIUM'
---ScootsVendorForge.frames.currency = {}
 ScootsVendorForge.textSize = 10
 ScootsVendorForge.borderThickness = 0.7
 ScootsVendorForge.currencyHeight = 10

--- a/src/ScootsVendorForge/ScootsVendorForge-utility.lua
+++ b/src/ScootsVendorForge/ScootsVendorForge-utility.lua
@@ -188,15 +188,15 @@ end
 
 function ScootsVendorForge.buildCurrencyArray(item,computeExpected)
     local currencies = {}
-	local forgeMult = {
-		(1/((1+(GetCustomGameData(29, 1494)/100))*0.05)),
-		(1/((1+(GetCustomGameData(29, 1494)/100))*0.007)),
-		(1/((1+(GetCustomGameData(29, 1494)/100))*0.001))
-	}
-	local mult = 1
-	if computeExpected then mult = forgeMult[ScootsVendorForge.getOption('forgelevel')] end
+    local forgeMult = {
+        (1/((1+(GetCustomGameData(29, 1494)/100))*0.05)),
+        (1/((1+(GetCustomGameData(29, 1494)/100))*0.007)),
+        (1/((1+(GetCustomGameData(29, 1494)/100))*0.001))
+    }
+    local mult = 1
+    if computeExpected then mult = forgeMult[ScootsVendorForge.getOption('forgelevel')] end
     if(item.cost ~= nil and item.cost > 0) then
-		local cost = item.cost * mult
+        local cost = item.cost * mult
         local gold = math.floor(cost / 10000)
         if(gold > 0) then
             table.insert(currencies, {
@@ -216,7 +216,7 @@ function ScootsVendorForge.buildCurrencyArray(item,computeExpected)
         end
         
         local copper = cost % 100
-		copper = math.floor(copper + 0.5)
+        copper = math.floor(copper + 0.5)
         if(copper > 0) then
             table.insert(currencies, {
                 ['name'] = 'Copper',

--- a/src/ScootsVendorForge/ScootsVendorForge-utility.lua
+++ b/src/ScootsVendorForge/ScootsVendorForge-utility.lua
@@ -184,3 +184,143 @@ ScootsVendorForge.canAfford = function(itemIndex, quantity)
     
     return true
 end
+
+
+function ScootsVendorForge.buildCurrencyArray(item,computeExpected)
+    local currencies = {}
+	local forgeMult = {
+		(1/((1+(GetCustomGameData(29, 1494)/100))*0.05)),
+		(1/((1+(GetCustomGameData(29, 1494)/100))*0.007)),
+		(1/((1+(GetCustomGameData(29, 1494)/100))*0.001))
+	}
+	local mult = 1
+	if computeExpected then mult = forgeMult[ScootsVendorForge.getOption('forgelevel')] end
+    if(item.cost ~= nil and item.cost > 0) then
+		local cost = item.cost * mult
+        local gold = math.floor(cost / 10000)
+        if(gold > 0) then
+            table.insert(currencies, {
+                ['name'] = 'Gold',
+                ['icon'] = 'Interface/MoneyFrame/UI-GoldIcon',
+                ['amnt'] = gold
+            })
+        end
+        
+        local silver = math.floor(cost / 100) % 100
+        if(silver > 0) then
+            table.insert(currencies, {
+                ['name'] = 'Silver',
+                ['icon'] = 'Interface/MoneyFrame/UI-SilverIcon',
+                ['amnt'] = silver
+            })
+        end
+        
+        local copper = cost % 100
+		copper = math.floor(copper + 0.5)
+        if(copper > 0) then
+            table.insert(currencies, {
+                ['name'] = 'Copper',
+                ['icon'] = 'Interface/MoneyFrame/UI-CopperIcon',
+                ['amnt'] = copper
+            })
+        end
+    end
+    
+    if(item.extCost == 1) then
+        local honorPoints, arenaPoints, itemCount = GetMerchantItemCostInfo(item.index) 
+        
+        if(honorPoints > 0) then
+            table.insert(currencies, {
+                ['name'] = 'Honor Points',
+                ['icon'] = ScootsVendorForge.honorIcon,
+                ['amnt'] = math.floor((honorPoints * mult) + 0.5)
+            })
+        end
+        
+        if(arenaPoints > 0) then
+            table.insert(currencies, {
+                ['name'] = 'Arena Points',
+                ['icon'] = 'Interface/PVPFrame/PVP-ArenaPoints-Icon',
+                ['amnt'] =  math.floor((arenaPoints * mult) + 0.5)
+            })
+        end
+        
+        if(itemCount > 0) then
+            for currencyIndex = 1, 3 do
+                local currencyTexture, currencyCount, currencyItemLink = GetMerchantItemCostItem(item.index, currencyIndex)
+                
+                if(currencyItemLink ~= nil) then
+                    local itemName = GetItemInfo(currencyItemLink)
+                    
+                    table.insert(currencies, {
+                        ['name'] = itemName,
+                        ['icon'] = currencyTexture,
+                        ['amnt'] =  math.floor((currencyCount * mult) +0.5)
+                    })
+                end
+            end
+        end
+    end
+    
+    return currencies
+end
+
+
+
+function ScootsVendorForge.getCurrencyFrame(itemIndex,index)
+    if(ScootsVendorForge.frames.items[itemIndex].currency[index] ~= nil) then
+        ScootsVendorForge.frames.items[itemIndex].currency[index]:Show()
+        return ScootsVendorForge.frames.items[itemIndex].currency[index]
+    end
+    
+    ScootsVendorForge.frames.items[itemIndex].currency[index] = CreateFrame('Frame', 'ScootsVendorForgeCurrencyFrame' .. index)
+    ScootsVendorForge.frames.items[itemIndex].currency[index]:SetFrameStrata(ScootsVendorForge.frameStrata)
+    ScootsVendorForge.frames.items[itemIndex].currency[index]:EnableMouse(true)
+    
+    ScootsVendorForge.frames.items[itemIndex].currency[index].text = ScootsVendorForge.frames.items[itemIndex].currency[index]:CreateFontString(nil, 'ARTWORK')
+    ScootsVendorForge.frames.items[itemIndex].currency[index].text:SetFont('Fonts\\FRIZQT__.TTF', ScootsVendorForge.textSize)
+    ScootsVendorForge.frames.items[itemIndex].currency[index].text:SetJustifyH('LEFT')
+    ScootsVendorForge.frames.items[itemIndex].currency[index].text:SetPoint('BOTTOMLEFT', 0, 0)
+    ScootsVendorForge.frames.items[itemIndex].currency[index].text:SetTextColor(1, 1, 1)
+                
+    ScootsVendorForge.frames.items[itemIndex].currency[index]:SetScript("OnEnter", function(self)
+        GameTooltip:SetOwner(self, "ANCHOR_TOPLEFT")
+        GameTooltip:SetText(self.currencyName)
+        GameTooltip:Show()
+    end)
+    
+    ScootsVendorForge.frames.items[itemIndex].currency[index]:SetScript("OnLeave", function(self)
+        GameTooltip:Hide()
+    end)
+    
+    return ScootsVendorForge.frames.items[itemIndex].currency[index]
+end
+
+function ScootsVendorForge.getExpCurrencyFrame(itemIndex,index)
+    if(ScootsVendorForge.frames.items[itemIndex].expCurrency[index] ~= nil) then
+        ScootsVendorForge.frames.items[itemIndex].expCurrency[index]:Show()
+        return ScootsVendorForge.frames.items[itemIndex].expCurrency[index]
+    end
+    
+    ScootsVendorForge.frames.items[itemIndex].expCurrency[index] = CreateFrame('Frame', 'ScootsVendorForgeCurrencyFrame' .. index)
+    ScootsVendorForge.frames.items[itemIndex].expCurrency[index]:SetFrameStrata(ScootsVendorForge.frameStrata)
+    ScootsVendorForge.frames.items[itemIndex].expCurrency[index]:EnableMouse(true)
+    
+    ScootsVendorForge.frames.items[itemIndex].expCurrency[index].text = ScootsVendorForge.frames.items[itemIndex].expCurrency[index]:CreateFontString(nil, 'ARTWORK')
+    ScootsVendorForge.frames.items[itemIndex].expCurrency[index].text:SetFont('Fonts\\FRIZQT__.TTF', ScootsVendorForge.textSize)
+    ScootsVendorForge.frames.items[itemIndex].expCurrency[index].text:SetJustifyH('LEFT')
+    ScootsVendorForge.frames.items[itemIndex].expCurrency[index].text:SetPoint('BOTTOMLEFT', 0, 0)
+    ScootsVendorForge.frames.items[itemIndex].expCurrency[index].text:SetTextColor(1, 1, 1)
+                
+    ScootsVendorForge.frames.items[itemIndex].expCurrency[index]:SetScript("OnEnter", function(self)
+        GameTooltip:SetOwner(self, "ANCHOR_TOPLEFT")
+       GameTooltip:SetText(self.expCurrencyName)
+        GameTooltip:Show()
+    end)
+    
+    ScootsVendorForge.frames.items[itemIndex].expCurrency[index]:SetScript("OnLeave", function(self)
+        GameTooltip:Hide()
+    end)
+    
+    return ScootsVendorForge.frames.items[itemIndex].expCurrency[index]
+end


### PR DESCRIPTION
Add Item costs to Item frames.
On mouseover shows the expected cost of buying that item until the desired forge level.